### PR TITLE
Remove max_size parameter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ Usage Example
     display = ST7735(display_bus, width=128, height=128)
 
     # Make the display context
-    splash = displayio.Group(max_size=10)
+    splash = displayio.Group()
     display.show(splash)
 
     color_bitmap = displayio.Bitmap(128, 128, 1)

--- a/examples/st7735_simpletest.py
+++ b/examples/st7735_simpletest.py
@@ -24,7 +24,7 @@ display_bus = displayio.FourWire(
 display = ST7735(display_bus, width=128, height=128)
 
 # Make the display context
-splash = displayio.Group(max_size=10)
+splash = displayio.Group()
 display.show(splash)
 
 color_bitmap = displayio.Bitmap(128, 128, 1)


### PR DESCRIPTION
Remove the `max_size` parameter. It is no longer used by `displayio.Group`
Ref: adafruit/circuitpython#4959

I don't have a ST7735 display to test with.